### PR TITLE
Add 'killing' status to prevent duplicate agent delete requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+CRITICAL: Claude MUST READ, IN FULL, the entire root `README.md` file at the
+start of any working session. It explains this project overall. Also, after a
+conversation is compacted, do not rely on a summary: RE-READ THE ENTIRE FILE
+into context. You MUST NOT do work without this ENTIRE FILE fully in context.
+
+In addition to that, Claude should be mindful of where its local shell is
+running and expect a different set of available local operations:
+
+- Locally on a developer laptop? In this case, most likely the current shell
+  has access to fly cli commands (`fly machines list --json` and such) and you
+  can use those commands via the bash tool to inspect state on remote machines.
+  You can also run the deployment management scripts in fly/* and the
+  developer's laptop can be expected to be connected to the wireguard network.
+
+- Inside a Thopter in Thopter Swarm? In this case, Claude does NOT have an
+  authenticated fly client, and can really only manage files in its local repo,
+  and do git operations. Outbound network access except for git, anthropic, and
+  common packaging repos is blocked by an egress firewall.
+
+In either case, the actual code for the hub server and the thopter machine
+scripts are not currently runnable in a development environment. It's intended
+to run only inside a properly provisioned fly machine. However, generally `npm
+run build` does work and is critical to check for initial typescript issue or
+other easily preventable code bugs before considering your work complete.
+

--- a/README.md
+++ b/README.md
@@ -33,10 +33,16 @@ Assuming you will want to commit changes, like new prompt templates, and collab 
 
 Authenticate the fly CLI, create an app to contain your swarm, issue certs:
 ```bash
+
+# install flyctl if you haven't:
+curl -L https://fly.io/install.sh
+# or
+brew install flyctl
+
 fly auth login
 fly apps create --org <your-org> --name <app-name> --save
 fly ssh issue             # for console access (tbh not sure if this is needed)
-fly wireguard create      # for private networking
+fly wireguard create      # for private networking. be sure to use a .conf extension, e.g. swarm.conf
 fly tokens create deploy  # save for .env
 ```
 
@@ -71,9 +77,9 @@ Access the golden claude web terminal (in the output of `recreate-gc.sh`) and ru
 
 First invite them to your fly.io org, then they can:
 ```bash
+brew install flyctl
 fly auth login
-fly ssh issue
-fly wireguard create
+fly wireguard create # be sure to use a .conf extension e.g. swarm.conf
 ```
 
 This gives them access to the dashboard, the ability to ssh and see logs on machines, etc.
@@ -107,8 +113,9 @@ You can create multiple thopters by issuing multiple comments with /thopter comm
 
 **Golden Claudes** - Authentication template
 - Persistent instances with authenticated homedir
-- Homedir contents copied to new thopters
+- Homedir contents copied to new thopters (except `.bashrc` as thopter initialization depends on it)
 - Tmux sessions with web terminal access for auth setup
+- The Claude credentials time out. You have to hop back in, run claude, and `/login` every couple of days, then quit claude.
 - **IMPORTANT:** don't leave Claude Code running in these machines. The filesystem needs to be static during copy to new thopters, and Claude Code runs background stuff that breaks that.
 
 **Thopters** - Autonomous agents

--- a/hub/public/styles.css
+++ b/hub/public/styles.css
@@ -330,6 +330,26 @@ main {
   padding-bottom: 10px;
 }
 
+/* User group styling */
+.user-group {
+  margin-bottom: 30px;
+}
+
+.user-group:last-child {
+  margin-bottom: 0;
+}
+
+.user-group-header {
+  color: #2c3e50;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 15px;
+  padding: 8px 12px;
+  background: #f8f9fa;
+  border-radius: 6px;
+  border-left: 4px solid #3498db;
+}
+
 /* Empty states */
 .empty-state {
   text-align: center;

--- a/hub/views/dashboard.ejs
+++ b/hub/views/dashboard.ejs
@@ -98,116 +98,123 @@
             <p>Agents will appear here when they are spawned and running.</p>
           </div>
         <% } else { %>
-          <div class="table-container">
-            <table class="agents-table">
-              <thead>
-                <tr>
-                  <th>ID</th>
-                  <th>Status</th>
-                  <th>Age</th>
-                  <th>Last Ping</th>
-                  <th>Task</th>
-                  <th></th>
-                  <th></th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                <% agents.forEach(agent => { %>
-                  <tr class="agent-row">
-                    <td class="agent-id-cell">
-                      <a href="/agent/<%= agent.id %>" class="agent-id-link">
-                        <%= agent.id %>
-                      </a>
-                      <% if (!agent.hasObserver) { %>
-                        <span class="orphaned-indicator" title="No observer data - agent may not be responding">⚠️</span>
-                      <% } %>
-                    </td>
-                    <td class="status-cell">
-                      <span class="agent-state <%= formatters.stateClass(agent.state) %>">
-                        <%= agent.state %>
-                      </span>
-                      <% const idleDuration = formatters.idleDuration(agent.idle_since, agent.state); %>
-                      <% if (idleDuration) { %>
-                        <span class="idle-duration">(<%= idleDuration %>)</span>
-                      <% } %>
-                    </td>
-                    <td class="age-cell">
-                      <% if (agent.spawnedAt) { %>
-                        <span title="<%= formatters.absoluteTime(agent.spawnedAt) %>">
-                          <%= formatters.relativeTime(agent.spawnedAt) %>
-                        </span>
-                      <% } else { %>
-                        <span class="no-data">—</span>
-                      <% } %>
-                    </td>
-                    <td class="activity-cell">
-                      <% if (agent.lastActivity) { %>
-                        <span title="<%= formatters.absoluteTime(agent.lastActivity) %>">
-                          <%= formatters.relativeTime(agent.lastActivity) %>
-                        </span>
-                      <% } else { %>
-                        <span class="no-data">—</span>
-                      <% } %>
-                    </td>
-                    <td class="repo-issue-cell">
-                      <div class="repo-issue-content">
-                        <% if (agent.repository) { %>
-                          <div class="repo-line">
-                            <a href="<%= formatters.gitHubUrl(agent.repository) %>" target="_blank">
-                              <%= agent.repository %>
+          <% agentGroups.forEach(group => { %>
+            <div class="user-group">
+              <h3 class="user-group-header">
+                👤 <%= group.user %> (<%= group.agents.length %> agent<%= group.agents.length === 1 ? '' : 's' %>)
+              </h3>
+              <div class="table-container">
+                <table class="agents-table">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Status</th>
+                      <th>Age</th>
+                      <th>Last Ping</th>
+                      <th>Task</th>
+                      <th></th>
+                      <th></th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% group.agents.forEach(agent => { %>
+                      <tr class="agent-row">
+                        <td class="agent-id-cell">
+                          <a href="/agent/<%= agent.id %>" class="agent-id-link">
+                            <%= agent.id %>
+                          </a>
+                          <% if (!agent.hasObserver) { %>
+                            <span class="orphaned-indicator" title="No observer data - agent may not be responding">⚠️</span>
+                          <% } %>
+                        </td>
+                        <td class="status-cell">
+                          <span class="agent-state <%= formatters.stateClass(agent.state) %>">
+                            <%= agent.state %>
+                          </span>
+                          <% const idleDuration = formatters.idleDuration(agent.idle_since, agent.state); %>
+                          <% if (idleDuration) { %>
+                            <span class="idle-duration">(<%= idleDuration %>)</span>
+                          <% } %>
+                        </td>
+                        <td class="age-cell">
+                          <% if (agent.spawnedAt) { %>
+                            <span title="<%= formatters.absoluteTime(agent.spawnedAt) %>">
+                              <%= formatters.relativeTime(agent.spawnedAt) %>
+                            </span>
+                          <% } else { %>
+                            <span class="no-data">—</span>
+                          <% } %>
+                        </td>
+                        <td class="activity-cell">
+                          <% if (agent.lastActivity) { %>
+                            <span title="<%= formatters.absoluteTime(agent.lastActivity) %>">
+                              <%= formatters.relativeTime(agent.lastActivity) %>
+                            </span>
+                          <% } else { %>
+                            <span class="no-data">—</span>
+                          <% } %>
+                        </td>
+                        <td class="repo-issue-cell">
+                          <div class="repo-issue-content">
+                            <% if (agent.repository) { %>
+                              <div class="repo-line">
+                                <a href="<%= formatters.gitHubUrl(agent.repository) %>" target="_blank">
+                                  <%= agent.repository %>
+                                </a>
+                              </div>
+                            <% } else { %>
+                              <div class="repo-line no-data">—</div>
+                            <% } %>
+                            <% if (agent.github && agent.github.issueNumber) { %>
+                              <div class="issue-line">
+                                <a href="<%= formatters.gitHubUrl(agent.repository, agent.github.issueNumber) %>" target="_blank">
+                                  #<%= agent.github.issueNumber %>: <%= formatters.truncateText(agent.github.issueTitle, 50) %>
+                                </a>
+                              </div>
+                            <% } %>
+                            <% if (agent.workBranch) { %>
+                              <div class="branch-line">
+                                <span class="branch-name"><%= agent.workBranch %></span>
+                              </div>
+                            <% } %>
+                          </div>
+                        </td>
+                        <td class="action-cell">
+                          <% if (agent.webTerminalUrl) { %>
+                            <a href="<%= agent.webTerminalUrl %>" class="table-btn terminal-btn" target="_blank" title="Open Web Terminal">
+                              Terminal
                             </a>
-                          </div>
-                        <% } else { %>
-                          <div class="repo-line no-data">—</div>
-                        <% } %>
-                        <% if (agent.github && agent.github.issueNumber) { %>
-                          <div class="issue-line">
-                            <a href="<%= formatters.gitHubUrl(agent.repository, agent.github.issueNumber) %>" target="_blank">
-                              #<%= agent.github.issueNumber %>: <%= formatters.truncateText(agent.github.issueTitle, 50) %>
+                          <% } %>
+                        </td>
+                        <td class="action-cell">
+                          <% if (agent.webTerminalUrl) { %>
+                            <% const sessionLogUrl = agent.webTerminalUrl.replace(':7681/', ':7791/'); %>
+                            <a href="<%= sessionLogUrl %>" class="table-btn session-log-btn" target="_blank" title="View Session Logs">
+                              Session Log
                             </a>
-                          </div>
-                        <% } %>
-                        <% if (agent.workBranch) { %>
-                          <div class="branch-line">
-                            <span class="branch-name"><%= agent.workBranch %></span>
-                          </div>
-                        <% } %>
-                      </div>
-                    </td>
-                    <td class="action-cell">
-                      <% if (agent.webTerminalUrl) { %>
-                        <a href="<%= agent.webTerminalUrl %>" class="table-btn terminal-btn" target="_blank" title="Open Web Terminal">
-                          Terminal
-                        </a>
-                      <% } %>
-                    </td>
-                    <td class="action-cell">
-                      <% if (agent.webTerminalUrl) { %>
-                        <% const sessionLogUrl = agent.webTerminalUrl.replace(':7681/', ':7791/'); %>
-                        <a href="<%= sessionLogUrl %>" class="table-btn session-log-btn" target="_blank" title="View Session Logs">
-                          Session Log
-                        </a>
-                      <% } %>
-                    </td>
-                    <td class="action-cell">
-                      <% if (agent.state === 'killing') { %>
-                        <button class="table-btn kill-btn disabled" disabled title="Agent is being killed">
-                          Killing...
-                        </button>
-                      <% } else { %>
-                        <form action="/agent/<%= agent.id %>/kill" method="POST" style="display: inline;" onsubmit="return confirm('Are you sure you want to kill this agent? This action cannot be undone.');">
-                          <button type="submit" class="table-btn kill-btn" title="Kill Agent">
-                            Kill
-                          </button>
-                        </form>
-                      <% } %>
-                    </td>
-                  </tr>
-                <% }); %>
-              </tbody>
-            </table>
-          </div>
+                          <% } %>
+                        </td>
+                        <td class="action-cell">
+                          <% if (agent.state === 'killing') { %>
+                            <button class="table-btn kill-btn disabled" disabled title="Agent is being killed">
+                              Killing...
+                            </button>
+                          <% } else { %>
+                            <form action="/agent/<%= agent.id %>/kill" method="POST" style="display: inline;" onsubmit="return confirm('Are you sure you want to kill this agent? This action cannot be undone.');">
+                              <button type="submit" class="table-btn kill-btn" title="Kill Agent">
+                                Kill
+                              </button>
+                            </form>
+                          <% } %>
+                        </td>
+                      </tr>
+                    <% }); %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          <% }); %>
         <% } %>
       </section>
 

--- a/thopter/Dockerfile
+++ b/thopter/Dockerfile
@@ -106,7 +106,7 @@ RUN chmod +x /usr/local/bin/observer.js && \
 ### RUN chmod +x /usr/local/bin/setup-firewall.sh
 
 # Default tmux configuration with proper terminal support (system-wide)
-RUN echo "set -g mouse off" > /etc/tmux.conf && \
+RUN echo "set -g mouse on" > /etc/tmux.conf && \
     echo "setw -g mode-keys vi" >> /etc/tmux.conf && \
     echo "set -g prefix C-a" >> /etc/tmux.conf && \
     echo "unbind C-b" >> /etc/tmux.conf && \


### PR DESCRIPTION
Resolves issue where users could create multiple destroy requests for the same agent by clicking the kill button repeatedly, causing the agent manager queue to become clogged with redundant operations.

Changes:
- Add 'killing' state to AgentState type definition
- Modify AgentManager.createDestroyRequest() to check for existing destroy requests and set agent state to 'killing' when creating a new request
- Update dashboard kill endpoint to use AgentManager instead of directly adding to state manager
- Update dashboard UI to show 'Killing...' disabled button for agents in killing state
- Add CSS styling for 'killing' state and disabled kill buttons
- Pass AgentManager instance to dashboard setup function

🤖 Generated with [Claude Code](https://claude.ai/code)