### PR TITLE
Convert workBranch text to GitHub tree links in dashboard

### DIFF
--- a/hub/src/dashboard/index.ts
+++ b/hub/src/dashboard/index.ts
@@ -89,7 +89,8 @@ router.get('/', (req: Request, res: Response) => {
         logLevelClass: utils.getLogLevelClass,
         idleDuration: utils.formatIdleDuration,
         truncateText: utils.truncateText,
-        gitHubUrl: utils.getGitHubUrl
+        gitHubUrl: utils.getGitHubUrl,
+        gitHubTreeUrl: utils.getGitHubTreeUrl
       }
     });
     
@@ -127,6 +128,7 @@ router.get('/agent/:id', (req: Request, res: Response) => {
         idleDuration: utils.formatIdleDuration,
         truncateText: utils.truncateText,
         gitHubUrl: utils.getGitHubUrl,
+        gitHubTreeUrl: utils.getGitHubTreeUrl,
         terminalUrl: (agentId: string) => `http://${agentId}.vm.${process.env.APP_NAME}.internal:${process.env.WEB_TERMINAL_PORT || '7681'}/`,
         sessionLogUrl: (agentId: string) => `http://${agentId}.vm.${process.env.APP_NAME}.internal:7791/`
       }

--- a/hub/src/lib/utils.ts
+++ b/hub/src/lib/utils.ts
@@ -196,6 +196,13 @@ export function getGitHubUrl(repository: string, issueNumber?: string): string {
 }
 
 /**
+ * Generate GitHub tree URL for repository branch
+ */
+export function getGitHubTreeUrl(repository: string, branch: string): string {
+  return `https://github.com/${repository}/tree/${branch}`;
+}
+
+/**
  * Get the service discovery URL for the hub dashboard
  */
 export function getDashboardUrl(): string {

--- a/hub/views/agent-detail.ejs
+++ b/hub/views/agent-detail.ejs
@@ -51,10 +51,14 @@
               </div>
             <% } %>
             
-            <% if (agent.workBranch) { %>
+            <% if (agent.workBranch && agent.repository) { %>
               <div class="detail-row">
                 <div class="detail-label">Work Branch:</div>
-                <div class="detail-value"><%= agent.workBranch %></div>
+                <div class="detail-value">
+                  <a href="<%= formatters.gitHubTreeUrl(agent.repository, agent.workBranch) %>" target="_blank">
+                    <%= agent.workBranch %>
+                  </a>
+                </div>
               </div>
             <% } %>
             

--- a/hub/views/dashboard.ejs
+++ b/hub/views/dashboard.ejs
@@ -173,9 +173,11 @@
                                 </a>
                               </div>
                             <% } %>
-                            <% if (agent.workBranch) { %>
+                            <% if (agent.workBranch && agent.repository) { %>
                               <div class="branch-line">
-                                <span class="branch-name"><%= agent.workBranch %></span>
+                                <a href="<%= formatters.gitHubTreeUrl(agent.repository, agent.workBranch) %>" target="_blank" class="branch-name">
+                                  <%= agent.workBranch %>
+                                </a>
                               </div>
                             <% } %>
                           </div>


### PR DESCRIPTION
- Added getGitHubTreeUrl formatter utility function
- Updated dashboard.ejs to link workBranch to GitHub tree view
- Updated agent-detail.ejs to link workBranch to GitHub tree view
- Modified dashboard route to include new formatter

Fixes #22: workBranch now links to https://github.com/{repo}/{repo}/tree/{workBranch}

🤖 Generated with [Claude Code](https://claude.ai/code)