### PR TITLE
Fix provisioner logging by using shell context

### DIFF
--- a/hub/src/lib/provisioner.ts
+++ b/hub/src/lib/provisioner.ts
@@ -114,8 +114,12 @@ export class ThopterProvisioner {
   private async logToThopterAsync(machineId: string, message: string): Promise<void> {
     try {
       const execAsync = promisify(exec);
+      // Sanitize message to prevent shell injection and quote issues
+      const sanitizedMessage = message.replace(/['"\\$`]/g, '');
+      
+      // Use sh -c to execute shell commands properly with -C flag
       await execAsync(
-        `fly ssh console -C "echo \\"\$(date '+%Y-%m-%d %H:%M:%S') [PROVISIONER] ${message}\\" >> /thopter/log" --machine ${machineId} -t "${this.flyToken}" -a ${this.appName}`,
+        `fly ssh console -C "sh -c 'echo \\"\\$(date \\'+%Y-%m-%d %H:%M:%S\\') [PROVISIONER] ${sanitizedMessage}\\" >> /thopter/log'" --machine ${machineId} -t "${this.flyToken}" -a ${this.appName}`,
         { 
           cwd: process.cwd()
         }


### PR DESCRIPTION
The fly ssh console -C flag does not execute commands in a shell context, so shell features like command substitution $(date) and redirection >> don't work. Wrap the command in 'sh -c' to enable proper shell execution for the provisioner logging functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)