### PR TITLE
Exclude .claude/projects from golden Claude snapshots

### DIFF
--- a/hub/src/lib/provisioner.ts
+++ b/hub/src/lib/provisioner.ts
@@ -611,7 +611,7 @@ ${request.github.issueBody}
         console.log(`  1️⃣ Creating snapshot on Golden Claude...`);
         const execAsync = promisify(exec);
         await execAsync(
-          `fly ssh console -C "tar czf ${gcSnapshotPath} -C /data/thopter --exclude='.bashrc' ." --machine ${gcMachineId} -t "${this.flyToken}" -a ${this.appName}`,
+          `fly ssh console -C "tar czf ${gcSnapshotPath} -C /data/thopter --exclude='.bashrc' --exclude='.claude/projects' ." --machine ${gcMachineId} -t "${this.flyToken}" -a ${this.appName}`,
           { 
             cwd: process.cwd()
           }


### PR DESCRIPTION
Added --exclude='.claude/projects' to the tar command in the Golden Claude data copy operation. This prevents GC session data from being included in snapshots and appearing in session logs for thopters.

Fixes: #41

🤖 Generated with [Claude Code](https://claude.ai/code)