### PR TITLE
Include git SHA in Docker image tags

### DIFF
--- a/fly/build-thopter.sh
+++ b/fly/build-thopter.sh
@@ -66,7 +66,9 @@ fi
 echo ""
 
 # Generate unique tag for this deployment
-THOPTER_TAG="thopter-$(date +%Y%m%d-%H%M%S)"
+GIT_SHA=$(git rev-parse --short=8 HEAD)
+EPOCH_SECONDS=$(date +%s)
+THOPTER_TAG="thopter-${GIT_SHA}-${EPOCH_SECONDS}"
 THOPTER_IMAGE="registry.fly.io/$APP_NAME:$THOPTER_TAG"
 
 echo "2. Building thopter image..."

--- a/fly/recreate-hub.sh
+++ b/fly/recreate-hub.sh
@@ -147,8 +147,9 @@ fi
 echo ""
 
 # Generate unique tag and machine name for this deployment
+GIT_SHA=$(git rev-parse --short=8 HEAD)
 EPOCH_SECONDS=$(date +%s)
-HUB_TAG="hub-$(date +%Y%m%d-%H%M%S)"
+HUB_TAG="hub-${GIT_SHA}-${EPOCH_SECONDS}"
 HUB_MACHINE_NAME="hub-$EPOCH_SECONDS"
 HUB_IMAGE="registry.fly.io/$APP_NAME:$HUB_TAG"
 


### PR DESCRIPTION
Update image tagging format from {hub|thopter}-YYYYMMDD-HHMMSS to {hub|thopter}-{8-char git sha}-{epoch seconds} for better traceability of deployed images to source code.

🤖 Generated with [Claude Code](https://claude.ai/code)