### PR TITLE
Unify golden claude structure and remove all legacy code

### DIFF
--- a/hub/public/styles.css
+++ b/hub/public/styles.css
@@ -468,41 +468,62 @@ main {
   white-space: nowrap;
 }
 
-/* State colors */
-.state-running {
+/* Machine state colors (Fly.io states) */
+.machine-state-started {
   background: #2ecc71;
   color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
 }
 
-.state-idle {
-  background: #f39c12;
-  color: white;
-}
-
-.state-provisioning {
-  background: #3498db;
-  color: white;
-}
-
-.state-orphaned {
-  background: #9b59b6;
-  color: white;
-}
-
-.state-killing {
-  background: #e67e22;
-  color: white;
-}
-
-.state-failed {
-  background: #e74c3c;
-  color: white;
-}
-
-.state-unknown {
+.machine-state-stopped {
   background: #95a5a6;
   color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
 }
+
+.machine-state-suspended {
+  background: #f39c12;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.machine-state-destroyed {
+  background: #e74c3c;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+/* Tmux state colors */
+.tmux-state-active {
+  background: #2ecc71;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.tmux-state-idle {
+  background: #f39c12;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
 
 .idle-duration {
   color: #7f8c8d;
@@ -1248,16 +1269,9 @@ main {
   white-space: nowrap;
 }
 
-/* Tmux state styling (similar to existing state styles) */
-.tmux-state {
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-size: 0.85em;
-  font-weight: 500;
-}
 
-/* For regular thopters - Claude running is good */
-.claude-process.process-running {
+/* Claude process state colors - specific naming */
+.claude-process-running {
   color: #28a745;
   background-color: #d4edda;
   padding: 2px 6px;
@@ -1266,7 +1280,7 @@ main {
   font-weight: 500;
 }
 
-.claude-process.process-not-found {
+.claude-process-notFound {
   color: #dc3545;
   background-color: #f8d7da;
   padding: 2px 6px;
@@ -1275,8 +1289,8 @@ main {
   font-weight: 500;
 }
 
-/* For golden claudes - Claude NOT running is good */
-.claude-process.process-good {
+/* For golden claudes - inverted logic */
+.claude-process-good {
   color: #28a745;
   background-color: #d4edda;
   padding: 2px 6px;
@@ -1285,9 +1299,83 @@ main {
   font-weight: 500;
 }
 
-.claude-process.process-warning {
+.claude-process-warning {
   color: #856404;
   background-color: #fff3cd;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+/* Request status colors - provision requests */
+.provision-request-status-pending {
+  background: #6c757d;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.provision-request-status-processing {
+  background: #3498db;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.provision-request-status-completed {
+  background: #2ecc71;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.provision-request-status-failed {
+  background: #e74c3c;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+/* Request status colors - destroy requests */
+.destroy-request-status-pending {
+  background: #6c757d;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.destroy-request-status-processing {
+  background: #e67e22;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.destroy-request-status-completed {
+  background: #2ecc71;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
+.destroy-request-status-failed {
+  background: #e74c3c;
+  color: white;
   padding: 2px 6px;
   border-radius: 3px;
   font-size: 0.85em;

--- a/hub/src/dashboard/index.ts
+++ b/hub/src/dashboard/index.ts
@@ -89,9 +89,7 @@ router.get('/', (req: Request, res: Response) => {
       formatters: {
         relativeTime: utils.formatRelativeTime,
         absoluteTime: utils.formatAbsoluteTime,
-        stateClass: utils.getStateClass,
         modeClass: utils.getModeClass,
-        requestStatusClass: utils.getRequestStatusClass,
         logLevelClass: utils.getLogLevelClass,
         idleDuration: utils.formatIdleDuration,
         truncateText: utils.truncateText,
@@ -137,7 +135,6 @@ router.get('/agent/:id', (req: Request, res: Response) => {
       formatters: {
         relativeTime: utils.formatRelativeTime,
         absoluteTime: utils.formatAbsoluteTime,
-        stateClass: utils.getStateClass,
         idleDuration: utils.formatIdleDuration,
         truncateText: utils.truncateText,
         gitHubUrl: utils.getGitHubUrl,

--- a/hub/src/lib/types.ts
+++ b/hub/src/lib/types.ts
@@ -83,14 +83,24 @@ export interface OrphanStatus {
 }
 
 
-// Golden Claude state tracking
+// Golden Claude state tracking - now using ThopterState structure
 export interface GoldenClaudeState {
-  machineId: string;
-  name: string;  // e.g. "default", "josh", "xyz"
-  state: 'running' | 'stopped';
-  webTerminalUrl?: string;
+  // === FLY INFRASTRUCTURE (authoritative, always present) ===
+  fly: {
+    id: string;              // machine.id
+    name: string;            // machine.name (e.g. "gc-default")
+    machineState: 'started' | 'stopped' | 'suspended' | 'destroyed';
+    region: string;          // machine.region
+    image: string;           // machine.image_ref.tag
+    createdAt: Date;         // machine.created_at (actual spawn time)
+  };
   
-  // Session data from observer (same structure as ThopterState.session)
+  // === HUB MANAGEMENT (ephemeral) ===
+  hub: {
+    killRequested: boolean;  // true when user requests kill, cleared on fail/timeout
+  };
+  
+  // === THOPTER SESSION (nullable, best-effort from observer) ===
   session?: {
     tmuxState: 'active' | 'idle';
     claudeProcess: 'running' | 'notFound';
@@ -98,6 +108,13 @@ export interface GoldenClaudeState {
     idleSince?: Date;
     screenDump: string;
   };
+  
+  // === GITHUB CONTEXT (nullable, not used for golden claudes) ===
+  // github field omitted - golden claudes don't have GitHub context
+  
+  // === GOLDEN CLAUDE SPECIFIC FIELDS ===
+  goldenClaudeName: string;  // e.g. "default", "josh", "xyz" (extracted from fly.name)
+  // webTerminalUrl is derived - computed from fly.machineState and fly.id
 }
 
 // Separate request types for provisioning and destroying

--- a/hub/src/lib/utils.ts
+++ b/hub/src/lib/utils.ts
@@ -47,28 +47,6 @@ export function formatAbsoluteTime(timestamp: string | Date): string {
   }
 }
 
-/**
- * Get CSS class for thopter state
- */
-export function getStateClass(state: string): string {
-  switch (state?.toLowerCase()) {
-    case 'running':
-      return 'state-running';
-    case 'idle':
-      return 'state-idle';
-    case 'provisioning':
-      return 'state-provisioning';
-    case 'orphaned':
-      return 'state-orphaned';
-    case 'killing':
-      return 'state-killing';
-    case 'failed':
-    case 'error':
-      return 'state-failed';
-    default:
-      return 'state-unknown';
-  }
-}
 
 /**
  * Get CSS class for operating mode
@@ -88,23 +66,6 @@ export function getModeClass(mode: string): string {
   }
 }
 
-/**
- * Get CSS class for request status
- */
-export function getRequestStatusClass(status: string): string {
-  switch (status?.toLowerCase()) {
-    case 'pending':
-      return 'status-pending';
-    case 'processing':
-      return 'status-processing';
-    case 'completed':
-      return 'status-completed';
-    case 'failed':
-      return 'status-failed';
-    default:
-      return 'status-unknown';
-  }
-}
 
 /**
  * Get CSS class for log level

--- a/hub/views/agent-detail.ejs
+++ b/hub/views/agent-detail.ejs
@@ -40,7 +40,7 @@
               <div class="detail-row">
                 <div class="detail-label">Machine State:</div>
                 <div class="detail-value">
-                  <span class="machine-state <%= formatters.stateClass(thopter.fly.machineState) %>">
+                  <span class="machine-state-<%= thopter.fly.machineState %>">
                     <%= thopter.fly.machineState %>
                   </span>
                 </div>
@@ -87,7 +87,7 @@
                 <div class="detail-row">
                   <div class="detail-label">Tmux State:</div>
                   <div class="detail-value">
-                    <span class="tmux-state <%= formatters.stateClass(thopter.session.tmuxState) %>">
+                    <span class="tmux-state-<%= thopter.session.tmuxState %>">
                       <%= thopter.session.tmuxState %>
                     </span>
                   </div>
@@ -96,7 +96,7 @@
                 <div class="detail-row">
                   <div class="detail-label">Claude Process:</div>
                   <div class="detail-value">
-                    <span class="claude-process <%= thopter.session.claudeProcess === 'running' ? 'process-running' : 'process-not-found' %>">
+                    <span class="claude-process-<%= thopter.session.claudeProcess %>">
                       <%= thopter.session.claudeProcess === 'running' ? 'running' : 'not found' %>
                     </span>
                   </div>

--- a/hub/views/dashboard.ejs
+++ b/hub/views/dashboard.ejs
@@ -59,21 +59,22 @@
                 <% goldenClaudes.forEach(gc => { %>
                   <tr class="gc-row">
                     <td class="gc-name-cell">
-                      <span class="gc-name">gc-<%= gc.name %></span>
+                      <span class="gc-name">gc-<%= gc.goldenClaudeName %></span>
                     </td>
                     <td class="status-cell">
                       <div class="status-multiline">
                         <div class="status-line">
-                          machine: <span class="machine-state <%= gc.state === 'running' ? 'state-running' : 'state-stopped' %>">
-                            <%= gc.state %>
+                          machine: <span class="machine-state-<%= gc.fly.machineState %>">
+                            <%= gc.fly.machineState %>
                           </span>
+                          (age: <%= formatters.relativeTime(gc.fly.createdAt) %>)
                           <% if (gc.session?.lastActivity) { %>
                             (last ping: <%= formatters.relativeTime(gc.session.lastActivity) %>)
                           <% } %>
                         </div>
                         <% if (gc.session) { %>
                           <div class="status-line">
-                            tmux: <span class="tmux-state <%= formatters.stateClass(gc.session.tmuxState) %>">
+                            tmux: <span class="tmux-state-<%= gc.session.tmuxState %>">
                               <%= gc.session.tmuxState %>
                             </span>
                             <% if (gc.session.idleSince) { %>
@@ -81,7 +82,7 @@
                             <% } %>
                           </div>
                           <div class="status-line">
-                            claude process: <span class="claude-process <%= gc.session.claudeProcess === 'notFound' ? 'process-good' : 'process-warning' %>">
+                            claude process: <span class="claude-process-<%= gc.session.claudeProcess === 'notFound' ? 'good' : 'warning' %>">
                               <%= gc.session.claudeProcess === 'running' ? 'running' : 'not found' %>
                               <% if (gc.session.claudeProcess === 'running') { %>
                                 <span class="warning-icon" title="Warning: Claude should be stopped in golden claudes for filesystem stability">⚠️</span>
@@ -95,13 +96,14 @@
                       </div>
                     </td>
                     <td class="gc-id-cell">
-                      <span class="machine-id" title="<%= gc.machineId %>">
-                        <%= gc.machineId %>
+                      <span class="machine-id" title="<%= gc.fly.id %>">
+                        <%= gc.fly.id %>
                       </span>
                     </td>
                     <td class="terminal-cell">
-                      <% if (gc.webTerminalUrl) { %>
-                        <a href="<%= gc.webTerminalUrl %>" target="_blank" class="table-btn terminal-btn">
+                      <% if (gc.fly.machineState === 'started') { %>
+                        <% const webTerminalUrl = `http://${gc.fly.id}.vm.${process.env.APP_NAME}.internal:${process.env.WEB_TERMINAL_PORT || '7681'}/`; %>
+                        <a href="<%= webTerminalUrl %>" target="_blank" class="table-btn terminal-btn">
                           Terminal
                         </a>
                       <% } else { %>
@@ -149,7 +151,7 @@
                         <td class="status-cell">
                           <div class="status-multiline">
                             <div class="status-line">
-                              machine: <span class="machine-state <%= formatters.stateClass(thopter.fly.machineState) %>">
+                              machine: <span class="machine-state-<%= thopter.fly.machineState %>">
                                 <%= thopter.fly.machineState %>
                               </span>
                               (age: <%= formatters.relativeTime(thopter.fly.createdAt) %>)
@@ -159,7 +161,7 @@
                             </div>
                             <% if (thopter.session) { %>
                               <div class="status-line">
-                                tmux: <span class="tmux-state <%= formatters.stateClass(thopter.session.tmuxState) %>">
+                                tmux: <span class="tmux-state-<%= thopter.session.tmuxState %>">
                                   <%= thopter.session.tmuxState %>
                                 </span>
                                 <% if (thopter.session.idleSince) { %>
@@ -167,7 +169,7 @@
                                 <% } %>
                               </div>
                               <div class="status-line">
-                                claude process: <span class="claude-process <%= thopter.session.claudeProcess === 'running' ? 'process-running' : 'process-not-found' %>">
+                                claude process: <span class="claude-process-<%= thopter.session.claudeProcess %>">
                                   <%= thopter.session.claudeProcess === 'running' ? 'running' : 'not found' %>
                                 </span>
                               </div>
@@ -274,7 +276,7 @@
                           <span class="orphaned-indicator" title="Orphaned: <%= orphanStatus.reason %>">⚠️</span>
                         </td>
                         <td class="status-cell">
-                          <span class="machine-state <%= formatters.stateClass(thopter.fly.machineState) %>">
+                          <span class="machine-state-<%= thopter.fly.machineState %>">
                             <%= thopter.fly.machineState %>
                           </span>
                         </td>
@@ -376,7 +378,7 @@
                           </span>
                         </td>
                         <td class="status-cell">
-                          <span class="machine-state <%= formatters.stateClass(thopter.fly.machineState) %>">
+                          <span class="machine-state-<%= thopter.fly.machineState %>">
                             <%= thopter.fly.machineState %>
                           </span>
                         </td>
@@ -473,7 +475,7 @@
                       </div>
                     </td>
                     <td class="status-cell">
-                      <span class="request-status <%= formatters.requestStatusClass(request.status) %>">
+                      <span class="provision-request-status-<%= request.status %>">
                         <%= request.status %>
                       </span>
                     </td>
@@ -542,7 +544,7 @@
                       <%= request.reason ? formatters.truncateText(request.reason, 40) : '—' %>
                     </td>
                     <td class="status-cell">
-                      <span class="request-status <%= formatters.requestStatusClass(request.status) %>">
+                      <span class="destroy-request-status-<%= request.status %>">
                         <%= request.status %>
                       </span>
                     </td>


### PR DESCRIPTION
- Change GoldenClaudeState to use ThopterState structure (minus github field)
- Use actual Fly machine states: started/stopped/suspended/destroyed
- Remove webTerminalUrl from storage - derive in templates
- Eliminate all legacy CSS classes and utility functions
- Add property-specific CSS selectors:
  - .machine-state-{started,stopped,suspended,destroyed}
  - .tmux-state-{active,idle}
  - .claude-process-{running,notFound,good,warning}
  - .provision-request-status-{pending,processing,completed,failed}
  - .destroy-request-status-{pending,processing,completed,failed}
- Remove getStateClass() and getRequestStatusClass() functions
- Update all templates to use new structure and CSS classes
- Zero backward compatibility - complete clean implementation

🤖 Generated with [Claude Code](https://claude.ai/code)