### PR TITLE
Fix file path references for Claude initialization

### DIFF
--- a/hub/src/lib/provisioner.ts
+++ b/hub/src/lib/provisioner.ts
@@ -846,7 +846,7 @@ ${request.github.issueBody}
         const encodedScript = Buffer.from(postCheckoutScript).toString('base64');
 
         await execAsync(
-          `fly ssh console -C "su - thopter -c 'tmux send-keys -t thopter \\"echo ${encodedScript} | base64 -d | bash && claude --dangerously-skip-permissions \\\\\\\"read ../prompt.md for your instructions\\\\\\\"\\" Enter'" --machine ${machineId} -t "${this.flyToken}" -a ${this.appName}`,
+          `fly ssh console -C "su - thopter -c 'tmux send-keys -t thopter \\"echo ${encodedScript} | base64 -d | bash && claude --dangerously-skip-permissions \\\\\\\"read ./prompt.md for your instructions\\\\\\\"\\" Enter'" --machine ${machineId} -t "${this.flyToken}" -a ${this.appName}`,
           {
             cwd: process.cwd()
           }

--- a/hub/templates/prompts/default.md
+++ b/hub/templates/prompts/default.md
@@ -1,12 +1,12 @@
 # Coding Agent Instructions
 
-**THIS `/data/thopter/prompt.md` FILE IS YOUR ANCHOR**. Never forget its
+**THIS `/data/thopter/workspace/prompt.md` FILE IS YOUR ANCHOR**. Never forget its
 location. Always include its path in any context compaction task along with
 instructions to re-read it. It contains critical information that you will need
 at every stage of your work.
 
 You are an autonomous coding agent working on a GitHub issue described in
-`/data/thopter/issue.json`
+`/data/thopter/workspace/issue.json`
 
 You are part of a platform called "Thopter Swarm" - an orchestrated system of
 coding agents spawned in containers (firecracker VMs actually) based on
@@ -29,7 +29,7 @@ coding agents spawned in containers (firecracker VMs actually) based on
   in the repo, as long as your new commits are on your branch only.
 
 ## General Workflow
-1. **First, read the issue** in `issue.json`
+1. **First, read the issue** in `/data/thopter/workspace/issue.json`
 3. Enter the repo directory: `cd {{repoName}}`
 4. **Determine base branch you'll branch from**: 
    - If the issue mentions a specific branch, checkout that branch first (e.g.


### PR DESCRIPTION
- Change initial prompt from ../prompt.md to ./prompt.md since Claude starts in the repo directory
- Update prompt template to reference correct paths for prompt.md and issue.json in /data/thopter/workspace

Fixes #60

🤖 Generated with [Claude Code](https://claude.ai/code)