### PR TITLE
Make stop hook notifications configurable

### DIFF
--- a/scripts/claude-hook-stop.sh
+++ b/scripts/claude-hook-stop.sh
@@ -20,8 +20,8 @@ if [ -n "$LAST_MSG" ]; then
     printf '%s' "$LAST_MSG" | thopter-status message 2>/dev/null || true
 fi
 
-# Send ntfy notification
-if [ -n "${THOPTER_NTFY_CHANNEL:-}" ]; then
+# Send ntfy notification (only when explicitly enabled via stopNotifications config)
+if [ -n "${THOPTER_NTFY_CHANNEL:-}" ] && [ "${THOPTER_STOP_NOTIFY:-}" = "1" ]; then
     NTFY_MSG="Waiting for input"
     [ -n "$LAST_MSG" ] && NTFY_MSG=$(printf '%s' "$LAST_MSG" | head -c 500)
     curl -s -H "Title: ${THOPTER_NAME}" -d "$NTFY_MSG" "ntfy.sh/$THOPTER_NTFY_CHANNEL" &

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -266,7 +266,7 @@ configCmd
   .argument("<key>", "Config key")
   .argument("<value>", "Config value")
   .action(async (key: string, value: string) => {
-    const { setRunloopApiKey, setRedisUrl, setNtfyChannel, setDefaultSnapshot } = await import("./config.js");
+    const { setRunloopApiKey, setRedisUrl, setNtfyChannel, setDefaultSnapshot, setStopNotifications } = await import("./config.js");
     switch (key) {
       case "runloopApiKey":
         setRunloopApiKey(value);
@@ -285,9 +285,13 @@ configCmd
         setDefaultSnapshot(value);
         console.log(`Set defaultSnapshotId to: ${value}`);
         break;
+      case "stopNotifications":
+        setStopNotifications(value === "true" || value === "1");
+        console.log(`Set stopNotifications to: ${value === "true" || value === "1"}`);
+        break;
       default:
         console.error(`Unknown config key: ${key}`);
-        console.error("Available keys: runloopApiKey, redisUrl, ntfyChannel, defaultSnapshotId");
+        console.error("Available keys: runloopApiKey, redisUrl, ntfyChannel, defaultSnapshotId, stopNotifications");
         process.exit(1);
     }
   });
@@ -297,12 +301,13 @@ configCmd
   .description("Get a config value")
   .argument("[key]", "Config key (omit to show all)")
   .action(async (key?: string) => {
-    const { getRunloopApiKey, getRedisUrl, getNtfyChannel, getDefaultSnapshot } = await import("./config.js");
+    const { getRunloopApiKey, getRedisUrl, getNtfyChannel, getDefaultSnapshot, getStopNotifications } = await import("./config.js");
     if (!key) {
-      console.log(`runloopApiKey:     ${getRunloopApiKey() ? "(set)" : "(not set)"}`);
-      console.log(`redisUrl:          ${getRedisUrl() ? "(set)" : "(not set)"}`);
-      console.log(`ntfyChannel:       ${getNtfyChannel() ?? "(not set)"}`);
-      console.log(`defaultSnapshotId: ${getDefaultSnapshot() ?? "(not set)"}`);
+      console.log(`runloopApiKey:       ${getRunloopApiKey() ? "(set)" : "(not set)"}`);
+      console.log(`redisUrl:            ${getRedisUrl() ? "(set)" : "(not set)"}`);
+      console.log(`ntfyChannel:         ${getNtfyChannel() ?? "(not set)"}`);
+      console.log(`defaultSnapshotId:   ${getDefaultSnapshot() ?? "(not set)"}`);
+      console.log(`stopNotifications:   ${getStopNotifications()}`);
     } else {
       switch (key) {
         case "runloopApiKey":
@@ -317,9 +322,12 @@ configCmd
         case "defaultSnapshotId":
           console.log(getDefaultSnapshot() ?? "(not set)");
           break;
+        case "stopNotifications":
+          console.log(getStopNotifications());
+          break;
         default:
           console.error(`Unknown config key: ${key}`);
-          console.error("Available keys: runloopApiKey, redisUrl, ntfyChannel, defaultSnapshotId");
+          console.error("Available keys: runloopApiKey, redisUrl, ntfyChannel, defaultSnapshotId, stopNotifications");
           process.exit(1);
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,7 @@ interface LocalConfig {
   redisUrl?: string;
   defaultSnapshotId?: string;
   ntfyChannel?: string;
+  stopNotifications?: boolean;
   envVars?: Record<string, string>;
 }
 
@@ -67,6 +68,16 @@ export function getNtfyChannel(): string | undefined {
 export function setNtfyChannel(channel: string): void {
   const config = loadLocalConfig();
   config.ntfyChannel = channel;
+  saveLocalConfig(config);
+}
+
+export function getStopNotifications(): boolean {
+  return loadLocalConfig().stopNotifications ?? false;
+}
+
+export function setStopNotifications(enabled: boolean): void {
+  const config = loadLocalConfig();
+  config.stopNotifications = enabled;
   saveLocalConfig(config);
 }
 

--- a/src/devbox.ts
+++ b/src/devbox.ts
@@ -19,6 +19,7 @@ import {
   escapeEnvValue,
   getDefaultSnapshot,
   getNtfyChannel,
+  getStopNotifications,
 } from "./config.js";
 
 /** Tool installation script that runs inside the devbox on first create. */
@@ -306,6 +307,9 @@ export async function createDevbox(opts: {
     const ntfyChannel = getNtfyChannel();
     if (ntfyChannel) {
       envLines.push(`export THOPTER_NTFY_CHANNEL="${escapeEnvValue(ntfyChannel)}"`);
+    }
+    if (getStopNotifications()) {
+      envLines.push(`export THOPTER_STOP_NOTIFY=1`);
     }
     // User-configured env vars from ~/.thopter.json envVars section
     for (const [key, value] of Object.entries(envVars)) {


### PR DESCRIPTION
## Summary

- Stop hook ntfy notifications are now off by default (previously always sent when ntfy channel configured)
- New `stopNotifications` boolean config property — enable with `thopter config set stopNotifications true`
- Claude's own notification hook (`claude-hook-notification.sh`) is unchanged — always sends ntfy when channel configured
- `THOPTER_STOP_NOTIFY=1` env var injected into devbox `.thopter-env` when enabled

Closes #71

## Test plan

- [ ] New thopter with default config — verify stop hook does NOT send ntfy notification
- [ ] `thopter config set stopNotifications true` then create thopter — verify stop hook DOES send ntfy
- [ ] Verify Claude notification hook still always sends ntfy (unchanged)
- [ ] `thopter config get` — verify stopNotifications shown
- [ ] `npm run build` — clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)