### PR TITLE
Add 'thopter use' command and session-start ntfy notification

### DIFF
--- a/scripts/claude-hook-session-start.sh
+++ b/scripts/claude-hook-session-start.sh
@@ -16,4 +16,9 @@ if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     node /usr/local/bin/thopter-last-message "$TRANSCRIPT" | thopter-status message 2>/dev/null || true
 fi
 
+# Send ntfy notification
+if [ -n "${THOPTER_NTFY_CHANNEL:-}" ]; then
+    curl -s -H "Title: ${THOPTER_NAME}" -d "Claude session started" "ntfy.sh/$THOPTER_NTFY_CHANNEL" &
+fi
+
 exit 0

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ interface LocalConfig {
   stopNotifications?: boolean;
   stopNotificationQuietPeriod?: number;
   envVars?: Record<string, string>;
+  defaultThopter?: string;
 }
 
 function loadLocalConfig(): LocalConfig {
@@ -117,6 +118,37 @@ export function setRunloopApiKey(key: string): void {
   const config = loadLocalConfig();
   config.runloopApiKey = key;
   saveLocalConfig(config);
+}
+
+export function getDefaultThopter(): string | undefined {
+  return loadLocalConfig().defaultThopter;
+}
+
+export function setDefaultThopter(name: string): void {
+  const config = loadLocalConfig();
+  config.defaultThopter = name;
+  saveLocalConfig(config);
+}
+
+export function clearDefaultThopter(): void {
+  const config = loadLocalConfig();
+  delete config.defaultThopter;
+  saveLocalConfig(config);
+}
+
+/**
+ * Resolve "." to the default thopter name. Pass through anything else unchanged.
+ * Throws if "." is used but no default is set.
+ */
+export function resolveThopterName(name: string): string {
+  if (name !== ".") return name;
+  const defaultName = getDefaultThopter();
+  if (!defaultName) {
+    throw new Error(
+      "No default thopter set. Set one with: thopter use <name>",
+    );
+  }
+  return defaultName;
 }
 
 // --- Devbox env vars ---


### PR DESCRIPTION
## Summary

- **Issue #102 — `thopter use`:** Set a default thopter context so you don't have to type the name on every command. Use `.` as a placeholder to reference the default thopter in any command.
- **Issue #91 — Session-start ntfy notification:** Send an ntfy push notification when Claude begins a new session on a thopter.

### Changes

- `src/config.ts`: Added `defaultThopter` field to `LocalConfig`, with getter/setter/clear functions and `resolveThopterName()` that maps `.` to the default
- `src/cli.ts`: Added `thopter use` command (view/set/clear); wired `resolveThopterName()` into all commands that take a thopter name (ssh, exec, destroy, suspend, resume, keepalive, attach, status, tail, tell, snapshot create, snapshot replace); added `defaultThopter` to `config get` and `config set`
- `scripts/claude-hook-session-start.sh`: Added ntfy push notification matching the existing pattern from notification and stop hooks

### Usage

```bash
thopter use my-worker        # set default
thopter use                  # view current
thopter use --clear          # unset

thopter ssh .                # SSH into default thopter
thopter tail . -f            # tail default thopter
thopter exec . -- uname -a   # exec on default thopter
thopter tell . "fix tests"   # tell default thopter
thopter status .             # status of default thopter
```

## Test plan

- [ ] `thopter use my-worker` sets default, `thopter use` shows it, `thopter use --clear` clears it
- [ ] `thopter ssh .` resolves to the default thopter name
- [ ] `thopter ssh .` with no default set shows error: "No default thopter set"
- [ ] `thopter config get` shows `defaultThopter` field
- [ ] `thopter config set defaultThopter foo` sets the value
- [ ] Session-start ntfy notification fires when `THOPTER_NTFY_CHANNEL` is set
- [ ] `npm run build` passes cleanly

Closes #102
Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)