### PR TITLE
Add -f follow mode to thopter status

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,13 +94,15 @@ program
   .alias("ls")
   .description("Show thopter status (unified Runloop + Redis view)")
   .argument("[name]", "Thopter name (omit for overview of all)")
-  .action(async (name: string | undefined) => {
+  .option("-f, --follow [interval]", "Re-render every N seconds (default: 5)")
+  .action(async (name: string | undefined, opts: { follow?: boolean | string }) => {
+    const follow = opts.follow === true ? 5 : opts.follow ? Number(opts.follow) : undefined;
     if (name) {
       const { showThopterStatus } = await import("./status.js");
       await showThopterStatus(resolveThopterName(name));
     } else {
       const { listDevboxes } = await import("./devbox.js");
-      await listDevboxes();
+      await listDevboxes({ follow });
     }
   });
 


### PR DESCRIPTION
## Summary
- Adds `-f, --follow [interval]` option to `thopter status` for watch mode that re-renders the table every N seconds (default 5, Ctrl+C to exit)
- Adds a **LAST MSG** column to the status table showing the last assistant message from Redis, truncated at 80 chars
- Extracts table rendering into an inner helper to avoid duplication between single-shot and follow modes

## Test plan
- [ ] `thopter status` — renders table once with new LAST MSG column
- [ ] `thopter status -f` — clears screen and refreshes every 5s, Ctrl+C exits cleanly
- [ ] `thopter status -f 2` — refreshes every 2s
- [ ] `npm run build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)