### PR TITLE
Add predefined repos list and `thopter repos` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Once you have a golden snapshot, you can dispatch Claude to work on tasks with a
 thopter run --repo owner/repo "fix the login bug described in issue #42 and submit a PR"
 ```
 
-This creates a thopter, clones the repo, and launches Claude with your prompt in a tmux session. You can then:
+This creates a thopter, clones the repo, and launches Claude with your prompt in a tmux session. Set up predefined repos with `thopter repos add` to get a numbered chooser when running without `--repo`. You can then:
 
 ```bash
 thopter status              # see all your thopters and what they're doing

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -62,6 +62,17 @@ Full command reference for the `thopter` CLI. See the [README](../README.md) for
 | `thopter snapshot default [name]` | View or set default snapshot |
 | `thopter snapshot default --clear` | Clear default snapshot |
 
+## Predefined Repos
+
+| Command | Description |
+|---------|-------------|
+| `thopter repos list` | List predefined repos |
+| `thopter repos add` | Add a predefined repo (interactive) |
+| `thopter repos remove` | Remove a predefined repo (interactive) |
+| `thopter repos edit` | Edit a predefined repo (interactive) |
+
+Predefined repos appear as a numbered chooser when running `thopter run` without `--repo`. Each entry can pin a branch or leave it unpinned (prompts at run time, defaults to `main`). Multiple entries for the same repo with different branches are supported.
+
 ## Environment Variables
 
 | Command | Description |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,9 @@ examples:
   thopter tail dev -n 50                 Show last 50 entries
   thopter tell dev "also fix the tests"  Send a message to Claude
   thopter tell dev -i "work on X now"    Interrupt Claude and redirect
+  thopter repos list                     List predefined repos
+  thopter repos add                      Add a predefined repo
+  thopter repos remove                   Remove a predefined repo
   thopter keepalive dev                   Reset keep-alive timer for a devbox
   thopter suspend dev                    Suspend a devbox
   thopter resume dev                     Resume a suspended devbox
@@ -174,6 +177,45 @@ program
         console.log("  Set one with: thopter use <name>");
       }
     }
+  });
+
+// --- repos ---
+const reposCmd = program
+  .command("repos")
+  .description("Manage predefined repositories for `thopter run`");
+
+reposCmd
+  .command("list")
+  .alias("ls")
+  .description("List predefined repos")
+  .action(async () => {
+    const { listRepos } = await import("./repos.js");
+    listRepos();
+  });
+
+reposCmd
+  .command("add")
+  .description("Add a predefined repo (interactive)")
+  .action(async () => {
+    const { addRepoInteractive } = await import("./repos.js");
+    await addRepoInteractive();
+  });
+
+reposCmd
+  .command("remove")
+  .alias("rm")
+  .description("Remove a predefined repo (interactive)")
+  .action(async () => {
+    const { removeRepoInteractive } = await import("./repos.js");
+    await removeRepoInteractive();
+  });
+
+reposCmd
+  .command("edit")
+  .description("Edit a predefined repo (interactive)")
+  .action(async () => {
+    const { editRepoInteractive } = await import("./repos.js");
+    await editRepoInteractive();
   });
 
 // --- destroy ---
@@ -377,7 +419,7 @@ configCmd
   .description("Get a config value")
   .argument("[key]", "Config key (omit to show all)")
   .action(async (key?: string) => {
-    const { getRunloopApiKey, getDefaultSnapshot, getDefaultRepo, getDefaultBranch, getStopNotifications, getStopNotificationQuietPeriod, getEnvVars, getDefaultThopter } = await import("./config.js");
+    const { getRunloopApiKey, getDefaultSnapshot, getDefaultRepo, getDefaultBranch, getStopNotifications, getStopNotificationQuietPeriod, getEnvVars, getDefaultThopter, getRepos } = await import("./config.js");
     if (!key) {
       console.log(`runloopApiKey:                  ${getRunloopApiKey() ? "(set)" : "(not set)"}`);
       console.log(`defaultSnapshotId:              ${getDefaultSnapshot() ?? "(not set)"}`);
@@ -386,6 +428,9 @@ configCmd
       console.log(`stopNotifications:              ${getStopNotifications()}`);
       console.log(`stopNotificationQuietPeriod:    ${getStopNotificationQuietPeriod()}s`);
       console.log(`defaultThopter:                 ${getDefaultThopter() ?? "(not set)"}`);
+      const repos = getRepos();
+      console.log(`repos:                          ${repos.length > 0 ? `${repos.length} configured (see: thopter repos list)` : "(none)"}`);
+
       const envVars = getEnvVars();
       const envCount = Object.keys(envVars).length;
       console.log(`envVars:                        ${envCount > 0 ? `${envCount} configured (see: thopter env list)` : "(none)"}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,11 @@ export interface UploadEntry {
   remote: string;
 }
 
+export interface RepoConfig {
+  repo: string;     // owner/repo format (e.g. "telepath-computer/thopter-swarm")
+  branch?: string;  // Pinned branch. If omitted → prompt at run time (default: main)
+}
+
 interface LocalConfig {
   runloopApiKey?: string;
   defaultSnapshotId?: string;
@@ -39,6 +44,7 @@ interface LocalConfig {
   stopNotificationQuietPeriod?: number;
   envVars?: Record<string, string>;
   defaultThopter?: string;
+  repos?: RepoConfig[];
 }
 
 function loadLocalConfig(): LocalConfig {
@@ -149,6 +155,39 @@ export function resolveThopterName(name: string): string {
     );
   }
   return defaultName;
+}
+
+// --- Predefined repos ---
+
+export function getRepos(): RepoConfig[] {
+  return loadLocalConfig().repos ?? [];
+}
+
+export function setRepos(repos: RepoConfig[]): void {
+  const config = loadLocalConfig();
+  config.repos = repos;
+  saveLocalConfig(config);
+}
+
+export function addRepo(entry: RepoConfig): void {
+  const config = loadLocalConfig();
+  if (!config.repos) config.repos = [];
+  config.repos.push(entry);
+  saveLocalConfig(config);
+}
+
+export function removeRepo(repo: string, branch?: string): boolean {
+  const config = loadLocalConfig();
+  if (!config.repos) return false;
+  const before = config.repos.length;
+  config.repos = config.repos.filter((r) => {
+    if (r.repo !== repo) return true;
+    if (branch !== undefined) return r.branch !== branch;
+    return false;
+  });
+  if (config.repos.length === before) return false;
+  saveLocalConfig(config);
+  return true;
 }
 
 // --- Devbox env vars ---

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -1,0 +1,189 @@
+/**
+ * Predefined repos: interactive chooser and management helpers.
+ */
+
+import { createInterface } from "node:readline";
+import { getRepos, setRepos, addRepo, type RepoConfig } from "./config.js";
+import { printTable } from "./output.js";
+
+function ask(rl: ReturnType<typeof createInterface>, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => resolve(answer.trim()));
+  });
+}
+
+function formatEntry(entry: RepoConfig): string {
+  return entry.branch ? `${entry.repo} (${entry.branch})` : `${entry.repo} (any branch)`;
+}
+
+/**
+ * Interactive repo chooser used by `thopter run` when --repo is not given.
+ * Returns { repo, branch } with branch always resolved (never undefined).
+ */
+export async function chooseRepo(
+  rl: ReturnType<typeof createInterface>,
+): Promise<{ repo: string; branch: string }> {
+  const repos = getRepos();
+
+  let repo: string;
+  let branch: string | undefined;
+
+  if (repos.length > 0) {
+    console.log("\nPredefined repos:");
+    for (let i = 0; i < repos.length; i++) {
+      console.log(`  ${i + 1}. ${formatEntry(repos[i])}`);
+    }
+    console.log(`  ${repos.length + 1}. Enter a different repo`);
+
+    const choice = await ask(rl, `\nChoose [1-${repos.length + 1}]: `);
+    const idx = parseInt(choice, 10);
+
+    if (idx >= 1 && idx <= repos.length) {
+      const entry = repos[idx - 1];
+      repo = entry.repo;
+      branch = entry.branch;
+    } else {
+      // "Enter a different repo" or invalid input
+      repo = await ask(rl, "Repository (owner/repo): ");
+      if (!repo) {
+        rl.close();
+        console.error("Error: Repository is required.");
+        process.exit(1);
+      }
+    }
+  } else {
+    console.log("\nNo predefined repos. Tip: run `thopter repos add` for faster workflow.");
+    repo = await ask(rl, "Repository (owner/repo): ");
+    if (!repo) {
+      rl.close();
+      console.error("Error: Repository is required.");
+      process.exit(1);
+    }
+  }
+
+  // If no pinned branch, prompt for one
+  if (!branch) {
+    const answer = await ask(rl, "Branch [main]: ");
+    branch = answer || "main";
+  }
+
+  return { repo, branch };
+}
+
+/**
+ * Interactive add: prompts for owner/repo and optional branch.
+ */
+export async function addRepoInteractive(): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  const repo = await ask(rl, "Repository (owner/repo): ");
+  if (!repo) {
+    console.log("Cancelled.");
+    rl.close();
+    return;
+  }
+
+  const branch = await ask(rl, "Branch (enter to leave unpinned): ");
+  rl.close();
+
+  const entry: RepoConfig = { repo };
+  if (branch) entry.branch = branch;
+
+  addRepo(entry);
+  console.log(`Added: ${formatEntry(entry)}`);
+}
+
+/**
+ * Interactive edit: pick from numbered list, then edit fields.
+ */
+export async function editRepoInteractive(): Promise<void> {
+  const repos = getRepos();
+  if (repos.length === 0) {
+    console.log("No predefined repos configured.");
+    console.log("  Add one with: thopter repos add");
+    return;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  console.log("\nPredefined repos:");
+  for (let i = 0; i < repos.length; i++) {
+    console.log(`  ${i + 1}. ${formatEntry(repos[i])}`);
+  }
+
+  const choice = await ask(rl, `\nEdit which? [1-${repos.length}]: `);
+  const idx = parseInt(choice, 10);
+  if (isNaN(idx) || idx < 1 || idx > repos.length) {
+    console.log("Cancelled.");
+    rl.close();
+    return;
+  }
+
+  const entry = repos[idx - 1];
+  const newRepo = await ask(rl, `Repository [${entry.repo}]: `);
+  const branchDefault = entry.branch ?? "(unpinned)";
+  const newBranch = await ask(rl, `Branch [${branchDefault}]: `);
+  rl.close();
+
+  if (newRepo) entry.repo = newRepo;
+  if (newBranch) {
+    entry.branch = newBranch === "none" ? undefined : newBranch;
+  }
+
+  repos[idx - 1] = entry;
+  setRepos(repos);
+  console.log(`Updated: ${formatEntry(entry)}`);
+}
+
+/**
+ * Interactive remove: pick from numbered list.
+ */
+export async function removeRepoInteractive(): Promise<void> {
+  const repos = getRepos();
+  if (repos.length === 0) {
+    console.log("No predefined repos configured.");
+    return;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  console.log("\nPredefined repos:");
+  for (let i = 0; i < repos.length; i++) {
+    console.log(`  ${i + 1}. ${formatEntry(repos[i])}`);
+  }
+
+  const choice = await ask(rl, `\nRemove which? [1-${repos.length}]: `);
+  rl.close();
+
+  const idx = parseInt(choice, 10);
+  if (isNaN(idx) || idx < 1 || idx > repos.length) {
+    console.log("Cancelled.");
+    return;
+  }
+
+  const removed = repos.splice(idx - 1, 1)[0];
+  setRepos(repos);
+  console.log(`Removed: ${formatEntry(removed)}`);
+}
+
+/**
+ * Print the list of predefined repos as a table.
+ */
+export function listRepos(): void {
+  const repos = getRepos();
+  if (repos.length === 0) {
+    console.log("No predefined repos configured.");
+    console.log("  Add one with: thopter repos add");
+    return;
+  }
+
+  console.log("Predefined repos:");
+  printTable(
+    ["#", "REPO", "BRANCH"],
+    repos.map((r, i) => [
+      String(i + 1),
+      r.repo,
+      r.branch ?? "(any)",
+    ]),
+  );
+}

--- a/thopter-json-reference.md
+++ b/thopter-json-reference.md
@@ -11,6 +11,7 @@
 | `stopNotifications` | boolean | no | Send ntfy.sh notification when Claude finishes a response. Default `true`. Notifications are suppressed during the quiet period after a user message (see `stopNotificationQuietPeriod`). Set to `false` to disable. |
 | `stopNotificationQuietPeriod` | number | no | Seconds after a user message during which stop notifications are suppressed (user is likely still engaged). Default `30`. Set to `0` to always send. |
 | `claudeMdPath` | string | no | Path to a custom CLAUDE.md deployed to `~/.claude/CLAUDE.md` on every new devbox. Omit to use the built-in default. |
+| `repos` | array | no | Predefined repositories for `thopter run`. Each entry: `{"repo": "owner/repo", "branch": "main"}`. Branch is optional — if omitted, user is prompted at run time (default: `main`). Multiple entries for the same repo with different branches are supported. Manage with `thopter repos {list,add,remove,edit}`. |
 | `uploads` | array | no | Files to copy to new devboxes at create time. Each entry: `{"local": "/path/on/laptop", "remote": "/path/on/devbox"}`. Runs after all other provisioning. |
 | `envVars` | object | yes | Key-value map of environment variables injected into every devbox. See below. |
 
@@ -42,6 +43,11 @@ Add any other env vars your devboxes need — they're all passed through, e.g. `
   "defaultSnapshotId": "jsw-golden",
   "defaultRepo": "telepath-computer/my-project",
   "defaultBranch": "main",
+  "repos": [
+    { "repo": "telepath-computer/my-app", "branch": "main" },
+    { "repo": "telepath-computer/my-app", "branch": "dev" },
+    { "repo": "telepath-computer/other-project" }
+  ],
   "stopNotificationQuietPeriod": 30,
   "claudeMdPath": "/Users/jw/projects/my-claude-instructions.md",
   "uploads": [


### PR DESCRIPTION
## Summary

- Adds a `repos` config field for predefined repositories that appear as a numbered chooser during `thopter run` when `--repo` is not given
- New `thopter repos` subcommands: `list`, `add`, `remove`, `edit` for managing the predefined repos list
- Fixes clone script to always `fetch origin` + `reset --hard origin/<branch>`, ensuring correct branch state even when the repo already exists from a snapshot

## Details

- Multiple entries for the same repo with different branches are supported (e.g. `my-app (main)`, `my-app (dev)`)
- Entries without a pinned branch prompt the user at run time (defaults to `main`)
- Existing `defaultRepo`/`defaultBranch` config still works as fallback when no repos are configured
- Branch now always defaults to `main` if unset after all resolution

Supersedes #124 (rebased onto latest main to resolve conflicts with #122 and #125).

## Test plan

- [ ] `thopter repos list` → "No predefined repos configured"
- [ ] `thopter repos add` → interactive add, verify in `~/.thopter.json`
- [ ] `thopter repos list` → shows the entry
- [ ] `thopter repos edit` → modify entry, verify
- [ ] `thopter repos remove` → remove entry, verify
- [ ] `thopter run --help` → options still work
- [ ] `thopter config get` → shows repos count
- [ ] `npm run build` → clean TypeScript compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)