### PR TITLE
Improve thopter status -f: responsive width + tight mode

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,9 +98,9 @@ program
   .alias("ls")
   .description("Show thopter status (unified Runloop + Redis view)")
   .argument("[name]", "Thopter name (omit for overview of all)")
-  .option("-f, --follow [interval]", "Re-render every N seconds (default: 5)")
+  .option("-f, --follow [interval]", "Re-render every N seconds (default: 10)")
   .action(async (name: string | undefined, opts: { follow?: boolean | string }) => {
-    const follow = opts.follow === true ? 5 : opts.follow ? Number(opts.follow) : undefined;
+    const follow = opts.follow === true ? 10 : opts.follow ? Number(opts.follow) : undefined;
     if (name) {
       const { showThopterStatus } = await import("./status.js");
       await showThopterStatus(resolveThopterName(name));

--- a/src/output.ts
+++ b/src/output.ts
@@ -29,3 +29,100 @@ export function printTable(
     console.log(`  ${line}`);
   }
 }
+
+export interface TableOptions {
+  /** Max total line width (e.g. process.stdout.columns) */
+  maxWidth?: number;
+  /** Column indices that flex (shrink/expand) to fill remaining space */
+  flexColumns?: number[];
+}
+
+/**
+ * Format a table as a string. Returns the formatted output.
+ * Pass headers=null to omit the header row and separator.
+ */
+export function formatTable(
+  headers: string[] | null,
+  rows: string[][],
+  options?: TableOptions,
+): string {
+  if (rows.length === 0) return "  (none)\n";
+
+  const numCols = (headers ?? rows[0]).length;
+  const maxWidth = options?.maxWidth;
+  const flexCols = new Set(options?.flexColumns ?? []);
+
+  // Calculate natural widths
+  const widths = Array.from({ length: numCols }, (_, i) => {
+    const headerLen = headers ? headers[i].length : 0;
+    const maxCell = Math.max(0, ...rows.map((r) => (r[i] ?? "").length));
+    return Math.max(headerLen, maxCell);
+  });
+
+  // Constrain flex columns to fit within maxWidth
+  if (flexCols.size > 0 && maxWidth != null) {
+    const indent = 2;
+    const gaps = (numCols - 1) * 2;
+    const fixedWidth = widths.reduce(
+      (sum, w, i) => sum + (flexCols.has(i) ? 0 : w),
+      0,
+    );
+    const available = maxWidth - indent - gaps - fixedWidth;
+
+    if (available > 0) {
+      // Sort flex columns by natural width so narrow ones keep their size
+      const flexArr = [...flexCols].sort((a, b) => widths[a] - widths[b]);
+      let remaining = available;
+      let unsettled = flexArr.length;
+
+      for (const i of flexArr) {
+        const share = Math.floor(remaining / unsettled);
+        if (widths[i] <= share) {
+          remaining -= widths[i];
+        } else {
+          widths[i] = share;
+          remaining -= share;
+        }
+        unsettled--;
+      }
+    } else {
+      for (const i of flexCols) {
+        widths[i] = 0;
+      }
+    }
+  }
+
+  const truncate = (s: string, w: number): string => {
+    if (w <= 0) return "";
+    if (s.length <= w) return s.padEnd(w);
+    if (w <= 3) return s.slice(0, w);
+    return s.slice(0, w - 3) + "...";
+  };
+
+  const formatRow = (cells: string[]): string => {
+    const parts: string[] = [];
+    for (let i = 0; i < numCols; i++) {
+      if (widths[i] <= 0) continue;
+      parts.push(truncate(cells[i] ?? "", widths[i]));
+    }
+    return `  ${parts.join("  ")}`;
+  };
+
+  const lines: string[] = [];
+
+  if (headers) {
+    lines.push(formatRow(headers));
+    const sepParts: string[] = [];
+    for (let i = 0; i < numCols; i++) {
+      if (widths[i] <= 0) continue;
+      sepParts.push("─".repeat(widths[i]));
+    }
+    lines.push(`  ${sepParts.join("  ")}`);
+  }
+
+  for (const row of rows) {
+    lines.push(formatRow(row));
+  }
+
+  return lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## Summary
- **Default follow interval**: 5s → 10s
- **Buffer-then-clear**: Computes full table output before clearing the screen, eliminating the blank flicker between refreshes
- **Responsive width**: Measures terminal columns; TASK and LAST MSG are flex columns that shrink to fill remaining space so rows never wrap
- **Tight mode**: Auto-detected when terminal is narrow — compresses owner to initials, abbreviates devbox status (`running`→`run`), drops column headers, heartbeat omits "ago", `yes`/`no` → `y`/`n`
- **New `formatTable()`** in `output.ts`: supports flex columns, optional null headers, and returns a string for buffered output

## Test plan
- [ ] `thopter status` — verify table renders without wrapping at current terminal width
- [ ] `thopter status -f` — verify default is now 10s, no blank flash between refreshes
- [ ] `thopter status -f 3` — custom interval still works
- [ ] Resize terminal narrow (<100 cols) and run `thopter status` — verify tight mode kicks in (no headers, initials, abbreviations)
- [ ] Resize terminal wide (>120 cols) and run `thopter status` — verify wide mode with full headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)