### PR TITLE
Status table: remove margin, tighter threshold, gray suspended rows

### DIFF
--- a/src/devbox.ts
+++ b/src/devbox.ts
@@ -442,6 +442,12 @@ export async function listDevboxes(opts?: { follow?: number }): Promise<void> {
     // Need at least 60 chars for the two flex columns to stay in wide mode
     const tight = wideOverhead > cols - 60;
 
+    // Gray out suspended rows
+    const DIM = "\x1b[90m";
+    const rowStyles = devboxes.map((db) =>
+      db.status === "suspended" ? DIM : null,
+    );
+
     // TASK index = 4, LAST MSG index = 7 (flex columns)
     if (tight) {
       const rows: string[][] = devboxes.map((db) => {
@@ -461,7 +467,7 @@ export async function listDevboxes(opts?: { follow?: number }): Promise<void> {
           msg,
         ];
       });
-      return formatTable(null, rows, { maxWidth: cols, flexColumns: [4, 7] });
+      return formatTable(null, rows, { maxWidth: cols, flexColumns: [4, 7], rowStyles });
     } else {
       const rows: string[][] = devboxes.map((db) => {
         const redis = redisMap.get(db.name);
@@ -483,7 +489,7 @@ export async function listDevboxes(opts?: { follow?: number }): Promise<void> {
       return formatTable(
         ["NAME", "OWNER", "DEVBOX", "AGENT", "TASK", "CLAUDE", "HEARTBEAT", "LAST MSG"],
         rows,
-        { maxWidth: cols, flexColumns: [4, 7] },
+        { maxWidth: cols, flexColumns: [4, 7], rowStyles },
       );
     }
   }

--- a/src/output.ts
+++ b/src/output.ts
@@ -35,6 +35,8 @@ export interface TableOptions {
   maxWidth?: number;
   /** Column indices that flex (shrink/expand) to fill remaining space */
   flexColumns?: number[];
+  /** ANSI style per data row (e.g. "\x1b[90m" for gray). Null/undefined = no style. */
+  rowStyles?: (string | null)[];
 }
 
 /**
@@ -119,8 +121,10 @@ export function formatTable(
     lines.push(sepParts.join("  "));
   }
 
-  for (const row of rows) {
-    lines.push(formatRow(row));
+  for (let r = 0; r < rows.length; r++) {
+    const style = options?.rowStyles?.[r];
+    const line = formatRow(rows[r]);
+    lines.push(style ? `${style}${line}\x1b[0m` : line);
   }
 
   return lines.join("\n") + "\n";


### PR DESCRIPTION
## Summary
Follow-up to #127 — these commits landed after the merge.

- Remove 2-space left margin from `formatTable` output (gutters between columns remain)
- Engage tight mode sooner: require 60 chars for flex columns (was 20), so tight mode kicks in below ~140 cols
- Show suspended devboxes in gray (ANSI 90) via new `rowStyles` option on `formatTable`

## Test plan
- [ ] `thopter status` — suspended rows render in gray, running rows in normal color
- [ ] Narrow terminal (<140 cols) — tight mode engages, no left margin
- [ ] Wide terminal — wide mode, no left margin

🤖 Generated with [Claude Code](https://claude.com/claude-code)