### PR TITLE
Multi-line layout for tight mode status display

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,14 +99,17 @@ program
   .description("Show thopter status (unified Runloop + Redis view)")
   .argument("[name]", "Thopter name (omit for overview of all)")
   .option("-f, --follow [interval]", "Re-render every N seconds (default: 10)")
-  .action(async (name: string | undefined, opts: { follow?: boolean | string }) => {
+  .option("-w, --wide", "Force wide (single-line) layout")
+  .option("-n, --narrow", "Force narrow (multi-line) layout")
+  .action(async (name: string | undefined, opts: { follow?: boolean | string; wide?: boolean; narrow?: boolean }) => {
     const follow = opts.follow === true ? 10 : opts.follow ? Number(opts.follow) : undefined;
+    const layout = opts.wide ? "wide" as const : opts.narrow ? "narrow" as const : undefined;
     if (name) {
       const { showThopterStatus } = await import("./status.js");
       await showThopterStatus(resolveThopterName(name));
     } else {
       const { listDevboxes } = await import("./devbox.js");
-      await listDevboxes({ follow });
+      await listDevboxes({ follow, layout });
     }
   });
 

--- a/src/devbox.ts
+++ b/src/devbox.ts
@@ -381,7 +381,7 @@ export async function createDevbox(opts: {
   }
 }
 
-export async function listDevboxes(opts?: { follow?: number }): Promise<void> {
+export async function listDevboxes(opts?: { follow?: number; layout?: "wide" | "narrow" }): Promise<void> {
   const client = getClient();
   const { getRedisInfoForNames, relativeTime } = await import("./status.js");
   const { formatTable } = await import("./output.js");
@@ -439,8 +439,10 @@ export async function listDevboxes(opts?: { follow?: number }): Promise<void> {
     }, 0);
     // gaps between all 8 columns (7 × 2) + fixed cols width
     const wideOverhead = 7 * 2 + wideFixedWidth;
-    // Need at least 60 chars for the two flex columns to stay in wide mode
-    const tight = wideOverhead > cols - 60;
+    // Explicit flag overrides auto-detection; otherwise need 60 chars for flex columns
+    const tight = opts?.layout === "narrow" ? true
+      : opts?.layout === "wide" ? false
+      : wideOverhead > cols - 60;
 
     // Gray out suspended rows
     const DIM = "\x1b[90m";


### PR DESCRIPTION
## Summary
- Tight mode now uses a multi-line block per devbox instead of cramming everything into one row:
  ```
  resisted-weather  JW  run  running  y  8s
    Task: improving thopter status display with responsive layout
    Last message: Done. PR created: https://github.com/...

  jw-golden  JW  susp  done  -  -
  ```
- Fixed columns on the first line, then indented `Task:` and `Last message:` lines that use the full terminal width
- Task/message lines omitted when empty (e.g. suspended devboxes with no data)
- Newlines and consecutive whitespace collapsed in task/message strings before truncation (both modes)

## Test plan
- [ ] `thopter status` at <140 cols — verify multi-line tight layout with indented Task/Last message
- [ ] `thopter status` at >140 cols — verify wide mode unchanged
- [ ] Suspended devboxes still render in gray, task/message lines included
- [ ] Devboxes with no task/message show only the fixed columns line

🤖 Generated with [Claude Code](https://claude.com/claude-code)