### PR TITLE
Fix links replacing Electron UI instead of opening in browser

### DIFF
--- a/electron-gui/src/main/index.ts
+++ b/electron-gui/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron'
+import { app, shell, BrowserWindow } from 'electron'
 import { join } from 'path'
 
 function createWindow(): void {
@@ -9,6 +9,20 @@ function createWindow(): void {
       nodeIntegration: true,
       contextIsolation: false,
     },
+  })
+
+  // Prevent any in-app navigation — open links in the external browser instead.
+  // Without this, clicking a link (e.g. an auth URL in the terminal) replaces
+  // the entire Electron UI with that page.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    event.preventDefault()
+    shell.openExternal(url)
+  })
+
+  // Handle window.open() calls the same way
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url)
+    return { action: 'deny' }
   })
 
   if (process.env.ELECTRON_RENDERER_URL) {

--- a/electron-gui/src/renderer/components/detail/LiveTerminalView.tsx
+++ b/electron-gui/src/renderer/components/detail/LiveTerminalView.tsx
@@ -104,10 +104,8 @@ export function LiveTerminalView({ name, visible = true, spawnInfo: spawnInfoPro
     })
     const fitAddon = new FitAddon()
     term.loadAddon(fitAddon)
-    term.loadAddon(new WebLinksAddon((event, uri) => {
-      if (event.metaKey || event.ctrlKey) {
-        shell.openExternal(uri)
-      }
+    term.loadAddon(new WebLinksAddon((_event, uri) => {
+      shell.openExternal(uri)
     }))
     term.open(container)
 


### PR DESCRIPTION
## Summary
- Add `will-navigate` and `setWindowOpenHandler` in the Electron main process to intercept all link navigation and open URLs in the external browser instead
- Remove the Ctrl/Cmd modifier requirement from the terminal `WebLinksAddon` handler — clicking a link in any live terminal now always opens it externally
- Fixes the bug where clicking an auth URL in the reauth modal's live terminal replaces the entire Electron app with that page

## Test plan
- [ ] Open a live terminal view in the detail panel, click a link in terminal output — should open in external browser
- [ ] Open the reauth modal, run `claude`, click the auth URL — should open in external browser, not replace the Electron UI
- [ ] Verify normal app navigation (tab switches, modal opens/closes) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)