### PR TITLE
Prevent Electron window navigation on link clicks

### DIFF
--- a/electron-gui/src/main/index.ts
+++ b/electron-gui/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron'
+import { app, shell, BrowserWindow } from 'electron'
 import { join } from 'path'
 
 function createWindow(): void {
@@ -9,6 +9,20 @@ function createWindow(): void {
       nodeIntegration: true,
       contextIsolation: false,
     },
+  })
+
+  // Prevent any in-app navigation — open links in the external browser instead.
+  // Without this, clicking a link (e.g. an auth URL in the terminal) replaces
+  // the entire Electron UI with that page.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    event.preventDefault()
+    shell.openExternal(url)
+  })
+
+  // Handle window.open() calls the same way
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url)
+    return { action: 'deny' }
   })
 
   if (process.env.ELECTRON_RENDERER_URL) {


### PR DESCRIPTION
## Summary
- Belt-and-suspenders fix: add `will-navigate` and `setWindowOpenHandler` in the Electron main process so any link click opens in the external browser instead of navigating the Electron window
- The LiveTerminalView already handles links correctly via WebLinksAddon (Cmd/Ctrl+Click → external browser), but this ensures no navigation can escape at the Electron level

## Test plan
- [ ] Cmd+Click a link in a live terminal — should open in external browser (unchanged)
- [ ] Verify app doesn't navigate away if a link is somehow triggered without the modifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)